### PR TITLE
Switch to version features instead of autodetection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,12 @@ keywords = ["pango", "gtk", "gnome"]
 [lib]
 name = "pango"
 
+[features]
+"1.31" = ["pango-sys/1.31"]
+"1.32" = ["1.31", "pango-sys/1.32"]
+"1.32.4" = ["1.32", "pango-sys/1.32.4"]
+"1.34" = ["1.32.4", "pango-sys/1.34"]
+
 [dependencies]
 glib = { git = "https://github.com/gtk-rs/glib" }
 libc = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,12 @@ name = "pango"
 "1.34" = ["1.32.4", "pango-sys/1.34"]
 
 [dependencies]
-glib = { git = "https://github.com/gtk-rs/glib" }
-libc = "0.1"
-pango-sys  = { git = "https://github.com/gtk-rs/sys" }
+libc = "0.2"
+
+[dependencies.pango-sys]
+git = "https://github.com/gtk-rs/sys"
+version = "0.3.0"
+
+[dependencies.glib]
+git = "https://github.com/gtk-rs/glib"
+version = "0.0.8"


### PR DESCRIPTION
Implement the reinstatement of version features outlined in https://github.com/gtk-rs/gtk/issues/243.

- Installed library version detection no longer impacts conditional compilation.
- Each crate defaults to supporting a particular minimal upstream version.
- Higher (newer) versions need to be enabled via cargo features e.g. `--features 3.16`, `features = ["3.16"]`.
- The selected version is checked against `pkg-config` aborting the build if it's too high.
- The use of `pkg-config` can be overridden by setting `GTK_LIB_DIR` env variable, which translates into `-L $GTK_LIB_DIR` linker argument. No version checks are done in this case.

[breaking change]