### PR TITLE
(#156): Manual implementations of PangoGravity functions

### DIFF
--- a/src/gravity.rs
+++ b/src/gravity.rs
@@ -1,0 +1,50 @@
+// Copyright 2019, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use glib::translate::*;
+use pango_sys;
+use Gravity;
+use GravityHint;
+use Matrix;
+use Script;
+
+impl Gravity {
+    pub fn to_rotation(&self) -> f64 {
+        unsafe { pango_sys::pango_gravity_to_rotation(self.to_glib()) }
+    }
+
+    pub fn get_for_matrix(matrix: &Matrix) -> Gravity {
+        unsafe {
+            from_glib(pango_sys::pango_gravity_get_for_matrix(
+                matrix.to_glib_none().0,
+            ))
+        }
+    }
+
+    pub fn get_for_script(script: Script, base_gravity: Gravity, hint: GravityHint) -> Gravity {
+        unsafe {
+            from_glib(pango_sys::pango_gravity_get_for_script(
+                script.to_glib(),
+                base_gravity.to_glib(),
+                hint.to_glib(),
+            ))
+        }
+    }
+
+    pub fn get_for_script_and_width(
+        script: Script,
+        wide: bool,
+        base_gravity: Gravity,
+        hint: GravityHint,
+    ) -> Gravity {
+        unsafe {
+            from_glib(pango_sys::pango_gravity_get_for_script_and_width(
+                script.to_glib(),
+                wide.to_glib(),
+                base_gravity.to_glib(),
+                hint.to_glib(),
+            ))
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub mod attr_list;
 pub mod attribute;
 pub mod font_description;
 mod functions;
+pub mod gravity;
 pub mod item;
 pub mod language;
 pub use language::Language;


### PR DESCRIPTION
Gravity is an enum, and so it didn't get its functions auto-generated
by gir.

Fixes https://github.com/gtk-rs/pango/issues/156