### PR TITLE
Don't use glib::ToBool anymore

### DIFF
--- a/src/language.rs
+++ b/src/language.rs
@@ -81,15 +81,19 @@ impl Language {
 
     pub fn matches(&self, range_list: &str) -> bool {
         unsafe {
-            pango_sys::pango_language_matches(self.to_glib_none().0, range_list.to_glib_none().0)
-                .to_bool()
+            from_glib(pango_sys::pango_language_matches(
+                self.to_glib_none().0,
+                range_list.to_glib_none().0,
+            ))
         }
     }
 
     pub fn includes_script(&self, script: Script) -> bool {
         unsafe {
-            pango_sys::pango_language_includes_script(self.to_glib_none().0, script.to_glib())
-                .to_bool()
+            from_glib(pango_sys::pango_language_includes_script(
+                self.to_glib_none().0,
+                script.to_glib(),
+            ))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@ extern crate pango_sys;
 extern crate glib;
 #[macro_use]
 extern crate bitflags;
-extern crate once_cell;
 extern crate libc;
+extern crate once_cell;
 
 #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
 #[cfg_attr(feature = "cargo-clippy", allow(useless_transmute))]


### PR DESCRIPTION
The trait is not necessary, we have FromGlib for the same purpose.