### PR TITLE
remove clippy lint about transmute cast

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@ extern crate libc;
 extern crate once_cell;
 
 #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
-#[cfg_attr(feature = "cargo-clippy", allow(useless_transmute))]
 #[cfg_attr(feature = "cargo-clippy", allow(should_implement_trait))]
 mod auto;
 pub use auto::functions::*;


### PR DESCRIPTION
Kind of part of gtk-rs/gir#896.

cc @EPashkin @sdroege 